### PR TITLE
Add request arg to the authenticate() method

### DIFF
--- a/lemonldap/auth/backends.py
+++ b/lemonldap/auth/backends.py
@@ -5,7 +5,7 @@ class LemonldapUserBackend(RemoteUserBackend):
     # Create a User object if not already in the database?
     create_unknown_user = True
 
-    def authenticate(self, lemonldap_user):
+    def authenticate(self, request, lemonldap_user):
         """
         The user informations passed as ``lemonldap_user`` dictionnary is considered
         as trusted. This method simply returns the ``User`` object with the given

--- a/lemonldap/auth/middleware.py
+++ b/lemonldap/auth/middleware.py
@@ -56,7 +56,7 @@ class LemonldapAuthenticationMiddleware(object):
             if request.user.username == self.clean_username(user_infos['username'], request):
                 return
         
-        user = auth.authenticate(lemonldap_user=user_infos)
+        user = auth.authenticate(request, lemonldap_user=user_infos)
         
         if user:
             # User is valid. Set request.user and persist user in the session


### PR DESCRIPTION
Hello,

Stumbled upon auth issues on a app upgraded to Django 2.1.x.

Found out that the `request` arg in the `authenticate()` method is mandatory since Django 2.1. Please see the [related release notes](https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1).

It looks like this should be compatible with older Django versions, but I haven't tested it.

Regards.